### PR TITLE
docs(readme): indica que Windows deve rodar via Git Bash ou WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Os clientes fazem agendamentos via **bot do WhatsApp**; ao confirmar, o agendame
   - Arquivo `calendar_credentials.json` na pasta `Backend/proj_integrador/` (service account do Google)
   - Token e webhook do WhatsApp Cloud API
 
+> **Windows**: rode os comandos via **Git Bash** ou **WSL**. O Makefile usa bash e não funciona em `cmd.exe` ou PowerShell puros.
+
 ---
 
 ## 🚀 Instalação e Configuração


### PR DESCRIPTION
## Contexto

A nota orientando usuários de Windows a rodarem os comandos via Git Bash ou WSL foi commitada na branch anterior (`feat/painel-admin-e-integracao-calendar`) **após** o merge do PR #17, então não entrou no `main`. Este PR abre o ajuste isolado.

## Mudança

- Adiciona uma linha no `README.md` (seção **Pré-requisitos**) alertando que o Makefile usa bash e, portanto, no Windows precisa ser executado via **Git Bash** ou **WSL**.